### PR TITLE
추가정보, 결과 페이지 UX 향상 및 카카오톡 공유하기 기능 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# api
+.env

--- a/index.html
+++ b/index.html
@@ -1,10 +1,15 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/src/assets/result-game.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Blinker</title>
+    <script
+      src="https://t1.kakaocdn.net/kakao_js_sdk/2.7.5/kakao.min.js"
+      integrity="sha384-dok87au0gKqJdxs7msEdBPNnKSRT+/mhTVzq+qOhcL464zXwvcrpjeWvyj1kCdq6"
+      crossorigin="anonymous"
+    ></script>
   </head>
   <body>
     <div id="root"></div>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,9 +3,9 @@ import { AddInfoPage } from "./pages/AddInfoPage";
 import "./styles/global.scss";
 import { ResultPage } from "./pages/ResultPage";
 
-// home: 홈페이지
+// /: 홈페이지
 // game: 게임 페이지
-// report: 태그 페이지
+// test: 태그 페이지
 // permission: 권한 페이지
 // quiz: 퀴즈 들어가기전 페이지
 // quiz/:id : 퀴즈 페이지(get 방식으로 api 가져오기?)
@@ -14,8 +14,8 @@ function App() {
   return (
     <BrowserRouter>
       <Routes>
-        {/* <Route path="/home" element={<HomePage />} /> */}
-        <Route path="/report" element={<AddInfoPage />} />
+        {/* <Route path="/" element={<HomePage />} /> */}
+        <Route path="/test" element={<AddInfoPage />} />
         {/* <Route path="/permission" element={<PermissionPage />} />
         <Route path="/quiz" element={<QuizHomePage />} />
         <Route path="/quiz/:id" element={<QuizPage />} /> */}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,7 +2,9 @@ import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { AddInfoPage } from "./pages/AddInfoPage";
 import "./styles/global.scss";
 import { ResultPage } from "./pages/ResultPage";
+import { useEffect } from "react";
 
+const API_KEY_KAKAO = import.meta.env.VITE_KAKAO_API_KEY;
 // /: 홈페이지
 // game: 게임 페이지
 // test: 태그 페이지
@@ -11,6 +13,13 @@ import { ResultPage } from "./pages/ResultPage";
 // quiz/:id : 퀴즈 페이지(get 방식으로 api 가져오기?)
 // result: 결과 페이지(post 방식으로 데이터를 보내고 결과를 반환 받을거임. 여기서 데이터 백엔으로 보낼꺼)
 function App() {
+  useEffect(() => {
+    // 이미 초기화됐다면 다시 하지 않음
+    if (!window.Kakao.isInitialized()) {
+      console.log(API_KEY_KAKAO);
+      window.Kakao.init(API_KEY_KAKAO);
+    }
+  }, []);
   return (
     <BrowserRouter>
       <Routes>

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -14,15 +14,15 @@ export const Header = () => {
   return (
     <div className={styles.container}>
       <div className={styles.contents}>
-        <Link to="/home" className={styles.logo}>
+        <Link to="/" className={styles.logo}>
           <img src={logo_header} />
         </Link>
         <div className={styles.nav}>
-          <Link to="/home" className={getNavClass("/home")}>
+          <Link to="/" className={getNavClass("/")}>
             Home
           </Link>
-          <Link to="/report" className={getNavClass("/report")}>
-            Report
+          <Link to="/test" className={getNavClass("/test")}>
+            Test
           </Link>
           <Link to="/quiz" className={getNavClass("/quiz")}>
             Quiz

--- a/src/components/Tag.jsx
+++ b/src/components/Tag.jsx
@@ -5,7 +5,7 @@ export const Tag = ({ tag, choiceTags, setChoiceTags }) => {
 
   const handleClick = () => {
     if (isSelected) {
-      setChoiceTags(choiceTags.filter((tag) => tag !== tag.value));
+      setChoiceTags(choiceTags.filter((el) => el !== tag.value));
     } else {
       setChoiceTags([...choiceTags, tag.value]);
     }
@@ -13,7 +13,7 @@ export const Tag = ({ tag, choiceTags, setChoiceTags }) => {
 
   return (
     <div
-      className={`${styles.container} ${isSelected ? styles.isClick : ""}`}
+      className={`${styles.container} ${isSelected && styles.isClick}`}
       onClick={handleClick}
     >
       <div className={`${styles.title}`}>{tag.title}</div>

--- a/src/components/Tag.jsx
+++ b/src/components/Tag.jsx
@@ -1,13 +1,13 @@
 import styles from "../styles/components/Tag.module.scss";
 
-export const Tag = ({ title, choiceTags, setChoiceTags }) => {
-  const isSelected = choiceTags.includes(title);
+export const Tag = ({ tag, choiceTags, setChoiceTags }) => {
+  const isSelected = choiceTags.includes(tag.value);
 
   const handleClick = () => {
     if (isSelected) {
-      setChoiceTags(choiceTags.filter((tag) => tag !== title));
+      setChoiceTags(choiceTags.filter((tag) => tag !== tag.value));
     } else {
-      setChoiceTags([...choiceTags, title]);
+      setChoiceTags([...choiceTags, tag.value]);
     }
   };
 
@@ -16,7 +16,7 @@ export const Tag = ({ title, choiceTags, setChoiceTags }) => {
       className={`${styles.container} ${isSelected ? styles.isClick : ""}`}
       onClick={handleClick}
     >
-      <div className={`${styles.title}`}>{title}</div>
+      <div className={`${styles.title}`}>{tag.title}</div>
     </div>
   );
 };

--- a/src/pages/AddInfoPage.jsx
+++ b/src/pages/AddInfoPage.jsx
@@ -78,7 +78,7 @@ const customStyles = {
     justifyContent: "center",
     transition: "background-color 0.3s ease",
     "&:hover": {
-      backgroundColor: "#0485A2",
+      backgroundColor: "#0485a233",
       cursor: "pointer",
     },
   }),

--- a/src/pages/AddInfoPage.jsx
+++ b/src/pages/AddInfoPage.jsx
@@ -8,23 +8,23 @@ import { arrow_right, move_char } from "../assets";
 import { MoveEyeTitle } from "../components/MoveEyeTitle";
 
 const tags = [
-  "두통",
-  "흐림시야",
-  "초점",
-  "가려움",
-  "안구건조",
-  "붓기",
-  "내부통증",
-  "충혈",
-  "따가움",
-  "떨림",
-  "빛 번짐",
-  "근육마비",
-  "피로",
-  "당김",
-  "어려운 눈뜨기",
-  "눈물 과다 분비",
-  "동공",
+  { title: "두통", value: "headache" },
+  { title: "흐림시야", value: "blurred_vision" },
+  { title: "초점", value: "accommodation_disorder" },
+  { title: "가려움", value: "pruritus" },
+  { title: "안구건조", value: "xerophthalmia" },
+  { title: "붓기", value: "tumefy" },
+  { title: "내부통증", value: "internal_pain" },
+  { title: "충혈", value: "hyperemia" },
+  { title: "따가움", value: "stinging" },
+  { title: "떨림", value: "quiver" },
+  { title: "빛 번짐", value: "Photopsia" },
+  { title: "근육마비", value: "paralysis" },
+  { title: "피로", value: "fatigue" },
+  { title: "당김", value: "pulling" },
+  { title: "어려운 눈뜨기", value: "blepharospasm" },
+  { title: "눈물 과다 분비", value: "epipphora" },
+  { title: "동공", value: "pupil" },
 ];
 
 // 옵션의 value값을 백에 전달해줘야함. 이때 숫자로 전달할 지, 문자로 전달할 지
@@ -257,7 +257,7 @@ export const AddInfoPage = () => {
             return (
               <Tag
                 key={index}
-                title={tag}
+                tag={tag}
                 choiceTags={choiceTags}
                 setChoiceTags={setChoiceTags}
               />

--- a/src/pages/AddInfoPage.jsx
+++ b/src/pages/AddInfoPage.jsx
@@ -76,6 +76,11 @@ const customStyles = {
     display: "flex",
     alignItems: "center",
     justifyContent: "center",
+    transition: "background-color 0.3s ease",
+    "&:hover": {
+      backgroundColor: "#0485A2",
+      cursor: "pointer",
+    },
   }),
   singleValue: (base) => ({
     // 맨위(선택된) 옵션의 스타일일
@@ -94,6 +99,7 @@ const customStyles = {
     backgroundColor: "#E8F8EE",
     padding: "18px",
     gap: "18px",
+    transition: "all 0.3s ease",
   }),
   option: (base) => ({
     // 옵션 하나하나의 스타일
@@ -107,6 +113,12 @@ const customStyles = {
     color: "black",
     fontSize: "24px",
     fontWeight: "500",
+    transition: "background-color 0.3s ease, color 0.3s ease",
+    "&:hover": {
+      backgroundColor: "#0E6F3A",
+      color: "white",
+      cursor: "pointer",
+    },
   }),
   dropdownIndicator: (base) => ({
     // 드롭다운 화살표 스타일

--- a/src/pages/ResultPage.jsx
+++ b/src/pages/ResultPage.jsx
@@ -55,6 +55,20 @@ export const ResultPage = () => {
   //   return <Loading />;
   // }
 
+
+  const handleShareKakao = () => {
+    window.Kakao.Share.sendCustom({
+      templateId: 120920,
+      templateArgs: {
+        // tip: `${result.tip}`
+        tip: `시력 1.0은 정상이나, 질병이 우려됩니다. 같은 연령대에서는 드문 상태입니다.`,
+        term: `4`,
+        score: `70`,
+        stretchTips: `고정 응시 운동(2분), 손바닥 온찜질(1분), 눈 굴리기(5회씩)`,
+      },
+    });
+  };
+
   return (
     <div className={styles.container}>
       <Header />
@@ -168,6 +182,16 @@ export const ResultPage = () => {
               <img src={arrow_right} />
             </Link>
           </div>
+        </div>
+      </div>
+      <div className={styles.shareContainer}>
+        <div className={styles.shareText}>
+          요약된 결과를 공유해보세요!
+          <br />
+          <span>(아래 버튼 클릭 시 카카오톡으로 공유할 수 있습니다!)</span>
+        </div>
+        <div className={styles.shareButton} onClick={handleShareKakao}>
+          공유하기
         </div>
       </div>
     </div>

--- a/src/styles/components/Tag.module.scss
+++ b/src/styles/components/Tag.module.scss
@@ -11,6 +11,7 @@
     cursor: pointer;
     background-color: #0485a233;
     transform: translateY(-10%);
+    box-shadow: 0 2px 4px rgba(78, 78, 78, 0.402);
   }
   .title {
     line-height: 20px;
@@ -18,7 +19,8 @@
     font-size: 30px;
     transition: background-color 0.3s ease;
   }
-  transition: background-color 0.3s ease, transform 0.3s ease, border 0.3s ease;
+  transition: background-color 0.3s ease, transform 0.3s ease, border 0.3s ease,
+    box-shadow 0.3s ease;
 }
 
 .isClick {

--- a/src/styles/components/Tag.module.scss
+++ b/src/styles/components/Tag.module.scss
@@ -18,7 +18,7 @@
     font-size: 30px;
     transition: background-color 0.3s ease;
   }
-  transition: background-color 0.3s ease, transform 0.3s ease;
+  transition: background-color 0.3s ease, transform 0.3s ease, border 0.3s ease;
 }
 
 .isClick {
@@ -26,6 +26,7 @@
   background-color: $sub-color;
   &:hover {
     cursor: pointer;
-    background-color: rgba(163, 0, 0, 0.232);
+    background-color: rgba(145, 54, 54, 0.232);
+    border: 1px solid rgb(157, 58, 58);
   }
 }

--- a/src/styles/components/header.module.scss
+++ b/src/styles/components/header.module.scss
@@ -1,7 +1,7 @@
 @use "../variables" as *;
 
 .container {
-  padding: 1.042vw;
+  padding: 1.042vw 0;
   position: fixed;
   top: 0;
   width: 100%;
@@ -19,9 +19,9 @@
       display: flex;
       align-items: center;
       justify-content: center;
-      gap: 200px;
+      gap: 10.417vw;
       .nav-item {
-        font-size: 2.188rem;
+        font-size: 2rem;
         text-decoration: none;
         color: $text-color-main;
         font-weight: 700;

--- a/src/styles/components/header.module.scss
+++ b/src/styles/components/header.module.scss
@@ -25,8 +25,9 @@
         text-decoration: none;
         color: $text-color-main;
         font-weight: 700;
+        transition: color 0.3s ease;
         &:hover {
-          text-decoration: underline;
+          color: #919994;
         }
       }
       .current {

--- a/src/styles/components/header.module.scss
+++ b/src/styles/components/header.module.scss
@@ -6,6 +6,7 @@
   top: 0;
   width: 100%;
   background-color: $background-color;
+  z-index: 1000;
   .contents {
     position: relative;
     width: 100%;

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -1,16 +1,22 @@
-@use './variables' as *;
+@use "./variables" as *;
 
 @font-face {
-    font-family: 'Pretendard-Regular';
-    src: url('https://fastly.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-Regular.woff') format('woff');
-    font-weight: 400;
-    font-style: normal;
+  font-family: "Pretendard-Regular";
+  src: url("https://fastly.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-Regular.woff")
+    format("woff");
+  font-weight: 400;
+  font-style: normal;
 }
 
 body {
   margin: 0;
   padding: 0;
   box-sizing: border-box;
-  font-family: 'Pretendard-Regular';
+  font-family: "Pretendard-Regular";
   background-color: $background-color;
+  user-select: none;
+  -webkit-user-drag: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
 }

--- a/src/styles/pages/AddInfoPage.module.scss
+++ b/src/styles/pages/AddInfoPage.module.scss
@@ -78,6 +78,7 @@
   transition: transform 0.7s ease-out, opacity 0.5s ease-out;
   position: fixed;
   bottom: 20px;
+  z-index: 1000;
 }
 .hidden {
   opacity: 0;

--- a/src/styles/pages/AddInfoPage.module.scss
+++ b/src/styles/pages/AddInfoPage.module.scss
@@ -65,6 +65,9 @@
     border: 4px solid #1c5f8e;
     box-shadow: 1.43px 5.71px 14.27px #0485a233;
     transform: translateY(-20%);
+    &:hover {
+      background-color: #0485a233;
+    }
   }
 }
 

--- a/src/styles/pages/AddInfoPage.module.scss
+++ b/src/styles/pages/AddInfoPage.module.scss
@@ -86,6 +86,7 @@
 
 .moveChar {
   position: fixed;
+  z-index: 1001;
   transition: transform 0.5s ease;
   img {
     transition: transform 0.5s ease;
@@ -93,7 +94,7 @@
 }
 
 .char1 {
-  bottom: -20%;
+  bottom: -190px;
   left: 74px;
 }
 .char2 {
@@ -102,7 +103,7 @@
   transform: rotate(90deg);
 }
 .char3 {
-  top: -20%;
+  top: -190px;
   right: 1%;
   transform: rotate(180deg);
 }

--- a/src/styles/pages/ResultPage.module.scss
+++ b/src/styles/pages/ResultPage.module.scss
@@ -217,4 +217,38 @@
       }
     }
   }
+  .shareContainer {
+    @include flex(column, $gap: 38px);
+    .shareText {
+      color: white;
+      text-align: center;
+      width: 100%;
+      font-size: 36px;
+      font-weight: bold;
+      span {
+        color: #c8edd4;
+        font-size: 26px;
+        font-weight: 100;
+      }
+    }
+    .shareButton {
+      @include flex();
+      border-radius: 15px;
+      padding: 19px 112px;
+      border: 4px solid #1c5f8e;
+      box-shadow: 0 4px 4px #ffffff14;
+      font-size: 24px;
+      font-weight: 700;
+      color: $text-color-main;
+      background-color: #0485A2;
+      &:hover {
+        background-color: #0485a233;
+        cursor: pointer;
+        box-shadow: 1.43px 5.71px 14.27px #0485a233;
+        transform: translateY(-20%);
+      }
+      transition: background-color 0.3s ease, box-shadow 0.3s ease,
+        transform 0.3s ease, border 0.3s ease;
+    }
+  }
 }


### PR DESCRIPTION
### 구현내용
- 태그를 백엔드에 영단어로 전달하기 위해 tags 배열을 객체 배열로 변경
- UX 향상을 위한 각종 부드러운 느낌 추가(transition)
- 카카오톡 공유하기 기능 추가
  - 링크 공유는 백엔드에서 db에 결과값이 저장되어 있으면 가능하나 우리 프로젝트는 바로 결과를 post로 반환해주기 때문에 링크로 결과페이지를 접근할 수 없음(post의 body에 전달할 내용이 새로고침하면 초기화됨, 즉 주소로 접근하면 아무런 값을 전달해줄 수 없으므로 body에 전달해줄 내용이 없을 경우 홈으로 이동)
  - 결과 페이지 이미지 공유 또한 로컬 폴더에 저장하는 방식이 아닌 웹 링크로 접근할 수 있는 이미지라면 공유 내용에 이미지를 포함할 수 있지만 우리는 이미지를 따로 외부저장소에 저장하지 않으므로 불가능
  - 따라서 결과를 요약하여 보내주는 느낌으로 공유하기 기능 구현
  - .env 파일에 키를 넣어주어야 함(나중에 배포할 때는 kakao developers에서 도메인 경로를 수정해주면 됨)
- 각종 수정 사항
  - 헤더와 움직이는 캐릭터(추가정보 페이지)를 최상단으로 보이게 설정
  - 라우터 변경(헤더 포함)
  - 전체적으로 드래그 불가능하게 설정(user-select: none;)

### 수정해야할 사항
- [ ] 결과 페이지에서 post body에 담을 내용 설정 및 도메인 경로 수정
- [ ] 결과 페이지에서 깜빡이의 한마디 표로 수정해야 함
- [ ] 백엔드와 통신 후 로딩의 진행 바 시간 맞추기